### PR TITLE
build: allow overriding toolchain via env variables

### DIFF
--- a/src/01_environment/appl.mk
+++ b/src/01_environment/appl.mk
@@ -12,10 +12,10 @@ ifeq ($(target),host)
 EXEC=$(EXE)_h
 endif
 
-CC=$(TOOLCHAIN)gcc
-LD=$(TOOLCHAIN)gcc
-AR=$(TOOLCHAIN)ar
-STRIP=$(TOOLCHAIN)strip
+CC?=$(TOOLCHAIN)gcc
+LD?=$(TOOLCHAIN)gcc
+AR?=$(TOOLCHAIN)ar
+STRIP?=$(TOOLCHAIN)strip
 
 OBJDIR=.obj/$(target)
 OBJS= $(addprefix $(OBJDIR)/, $(SRCS:.c=.o))

--- a/src/02_modules/procstat/Makefile
+++ b/src/02_modules/procstat/Makefile
@@ -2,20 +2,20 @@ EXE=procstat
 SRCS=$(wildcard *.c) 
 
 ifeq ($(TARGET), host)
-CC=gcc
-LD=gcc
-STRIP=strip
-CFLAGS=-Wall -Wextra -g -c -O0 -MD -std=c99
-OBJDIR=.obj/host
+CC?=gcc
+LD?=gcc
+STRIP?=strip
+CFLAGS=-Wall -Wextra -g -c -O0 -MD -std=c99 ${EXTRA_CFLAGS}
+OBJDIR?=.obj/host
 EXEC=$(EXE)_h
 
 else
 TOOLCHAIN_PATH=/buildroot/output/host/usr/bin/
 TOOLCHAIN=$(TOOLCHAIN_PATH)aarch64-buildroot-linux-gnu-
 
-CC=$(TOOLCHAIN)gcc
-LD=$(TOOLCHAIN)gcc
-STRIP=$(TOOLCHAIN)strip
+CC?=$(TOOLCHAIN)gcc
+LD?=$(TOOLCHAIN)gcc
+STRIP?=$(TOOLCHAIN)strip
 
 CFLAGS+=-pedantic -Wall -Wextra -g -c -mcpu=cortex-a53 -O0 -MD -std=gnu11
 CPPFLAGS+=-pedantic -Wall -Wextra -g -c -mcpu=cortex-a53 -O0 -MD -std=gnu11

--- a/src/03_drivers/exercice01/Makefile
+++ b/src/03_drivers/exercice01/Makefile
@@ -5,7 +5,7 @@ ifeq ($(target),)
 target=nano
 endif
 
-CFLAGS=-Wall -Wextra -g -c -O0 -MD -std=gnu11
+CFLAGS=-Wall -Wextra -g -c -O0 -MD -std=gnu11 ${EXTRA_CFLAGS}
 
 TOOLCHAIN_PATH=/buildroot/output/host/usr/bin/
 TOOLCHAIN=$(TOOLCHAIN_PATH)aarch64-linux-
@@ -14,10 +14,10 @@ CFLAGS+=-mcpu=cortex-a53 -funwind-tables
 OBJDIR=.obj/nano
 EXEC=$(EXE)
 
-CC=$(TOOLCHAIN)gcc
-LD=$(TOOLCHAIN)gcc
-AR=$(TOOLCHAIN)ar
-STRIP=$(TOOLCHAIN)strip
+CC?=$(TOOLCHAIN)gcc
+LD?=$(TOOLCHAIN)gcc
+AR?=$(TOOLCHAIN)ar
+STRIP?=$(TOOLCHAIN)strip
 
 OBJDIR=.obj/$(target)
 OBJS= $(addprefix $(OBJDIR)/, $(SRCS:.c=.o))

--- a/src/03_drivers/exercice04/Makefile
+++ b/src/03_drivers/exercice04/Makefile
@@ -8,10 +8,10 @@ CFLAGS+=-mcpu=cortex-a53 -funwind-tables
 
 OBJDIR=.obj
 
-CC=$(TOOLCHAIN)gcc
-LD=$(TOOLCHAIN)gcc
-AR=$(TOOLCHAIN)ar
-STRIP=$(TOOLCHAIN)strip
+CC?=$(TOOLCHAIN)gcc
+LD?=$(TOOLCHAIN)gcc
+AR?=$(TOOLCHAIN)ar
+STRIP?=$(TOOLCHAIN)strip
 OBJS+=$(addprefix $(OBJDIR)/, $(SRCS:.c=.o))
 
 .PHONY: all clean

--- a/src/03_drivers/sample01/Makefile
+++ b/src/03_drivers/sample01/Makefile
@@ -5,7 +5,7 @@ TOOLCHAIN=$(TOOLCHAIN_PATH)aarch64-linux-
 CFLAGS+=-Wall -Wextra -g -O0 -std=gnu11
 CFLAGS+=-mcpu=cortex-a53 -funwind-tables
 
-CC=$(TOOLCHAIN)gcc
+CC?=$(TOOLCHAIN)gcc
 
 
 all: $(objects)

--- a/src/06_optimization/clock/Makefile
+++ b/src/06_optimization/clock/Makefile
@@ -5,7 +5,7 @@ ifeq ($(target),)
 target=nano
 endif
 
-CFLAGS=-Wall -Wextra -g -c -O0 -MD -std=gnu11 -D_GNU_SOURCE
+CFLAGS=-Wall -Wextra -g -c -O0 -MD -std=gnu11 -D_GNU_SOURCE ${EXTRA_CFLAGS}
 
 ifeq ($(target),nano)
 TOOLCHAIN_PATH=/buildroot/output/host/usr/bin/
@@ -20,11 +20,11 @@ ifeq ($(target),host)
 EXEC=$(EXE)_h
 endif
 
-CC=$(TOOLCHAIN)gcc
-LD=$(TOOLCHAIN)gcc
-AR=$(TOOLCHAIN)ar
-STRIP=$(TOOLCHAIN)strip
-OBJDUMP=$(TOOLCHAIN)objdump
+CC?=$(TOOLCHAIN)gcc
+LD?=$(TOOLCHAIN)gcc
+AR?=$(TOOLCHAIN)ar
+STRIP?=$(TOOLCHAIN)strip
+OBJDUMP?=$(TOOLCHAIN)objdump
 
 OBJDIR=.obj/$(target)
 OBJS= $(addprefix $(OBJDIR)/, $(SRCS:.c=.o))

--- a/src/06_optimization/ex01/Makefile
+++ b/src/06_optimization/ex01/Makefile
@@ -5,7 +5,7 @@ ifeq ($(target),)
 target=nano
 endif
 
-CFLAGS=-Wall -Wextra -g -c -O1 -MD -std=gnu11 -D_GNU_SOURCE
+CFLAGS=-Wall -Wextra -g -c -O1 -MD -std=gnu11 -D_GNU_SOURCE ${EXTRA_CFLAGS}
 
 ifeq ($(target),nano)
 TOOLCHAIN_PATH=/buildroot/output/host/usr/bin/
@@ -20,11 +20,11 @@ ifeq ($(target),host)
 EXEC=$(EXE)_h
 endif
 
-CC=$(TOOLCHAIN)gcc
-LD=$(TOOLCHAIN)gcc
-AR=$(TOOLCHAIN)ar
-STRIP=$(TOOLCHAIN)strip
-OBJDUMP=$(TOOLCHAIN)objdump
+CC?=$(TOOLCHAIN)gcc
+LD?=$(TOOLCHAIN)gcc
+AR?=$(TOOLCHAIN)ar
+STRIP?=$(TOOLCHAIN)strip
+OBJDUMP?=$(TOOLCHAIN)objdump
 
 OBJDIR=.obj/$(target)
 OBJS= $(addprefix $(OBJDIR)/, $(SRCS:.c=.o))

--- a/src/06_optimization/ex02/Makefile
+++ b/src/06_optimization/ex02/Makefile
@@ -5,7 +5,7 @@ ifeq ($(target),)
 target=nano
 endif
 
-CFLAGS=-Wall -Wextra -g -c -O0 -MD -std=gnu11 -D_GNU_SOURCE
+CFLAGS=-Wall -Wextra -g -c -O0 -MD -std=gnu11 -D_GNU_SOURCE ${EXTRA_CFLAGS}
 
 ifeq ($(target),nano)
 TOOLCHAIN_PATH=/buildroot/output/host/usr/bin/
@@ -20,11 +20,11 @@ ifeq ($(target),host)
 EXEC=$(EXE)_h
 endif
 
-CC=$(TOOLCHAIN)gcc
-LD=$(TOOLCHAIN)gcc
-AR=$(TOOLCHAIN)ar
-STRIP=$(TOOLCHAIN)strip
-OBJDUMP=$(TOOLCHAIN)objdump
+CC?=$(TOOLCHAIN)gcc
+LD?=$(TOOLCHAIN)gcc
+AR?=$(TOOLCHAIN)ar
+STRIP?=$(TOOLCHAIN)strip
+OBJDUMP?=$(TOOLCHAIN)objdump
 
 OBJDIR=.obj/$(target)
 OBJS= $(addprefix $(OBJDIR)/, $(SRCS:.c=.o))

--- a/src/06_optimization/gcov/Makefile
+++ b/src/06_optimization/gcov/Makefile
@@ -1,5 +1,5 @@
 CC?=gcc
-CFLAGS=-std=c11 -Wall -g -fprofile-arcs -ftest-coverage
+CFLAGS=-std=c11 -Wall -g -fprofile-arcs -ftest-coverage ${EXTRA_CFLAGS}
 SOURCES=$(wildcard *.c)
 OBJECTS=$(SOURCES:.c=.o)
 EXECUTABLE=example-gcov

--- a/src/06_optimization/gpio/Makefile
+++ b/src/06_optimization/gpio/Makefile
@@ -5,7 +5,7 @@ ifeq ($(target),)
 target=nano
 endif
 
-CFLAGS=-Wall -Wextra -g -c -O1 -MD -std=gnu11 -D_GNU_SOURCE
+CFLAGS=-Wall -Wextra -g -c -O1 -MD -std=gnu11 -D_GNU_SOURCE ${EXTRA_CFLAGS}
 
 ifeq ($(target),nano)
 TOOLCHAIN_PATH=/buildroot/output/host/usr/bin/
@@ -20,11 +20,11 @@ ifeq ($(target),host)
 EXEC=$(EXE)_h
 endif
 
-CC=$(TOOLCHAIN)gcc
-LD=$(TOOLCHAIN)gcc
-AR=$(TOOLCHAIN)ar
-STRIP=$(TOOLCHAIN)strip
-OBJDUMP=$(TOOLCHAIN)objdump
+CC?=$(TOOLCHAIN)gcc
+LD?=$(TOOLCHAIN)gcc
+AR?=$(TOOLCHAIN)ar
+STRIP?=$(TOOLCHAIN)strip
+OBJDUMP?=$(TOOLCHAIN)objdump
 
 OBJDIR=.obj/$(target)
 OBJS= $(addprefix $(OBJDIR)/, $(SRCS:.c=.o))

--- a/src/06_optimization/gprof/Makefile
+++ b/src/06_optimization/gprof/Makefile
@@ -1,5 +1,5 @@
 CC?=gcc
-CFLAGS=-std=c11 -Wall -pg
+CFLAGS=-std=c11 -Wall -pg ${EXTRA_CFLAGS}
 SOURCES=$(wildcard *.c)
 OBJECTS=$(SOURCES:.c=.o)
 EXECUTABLE=example-gprof

--- a/src/06_optimization/gprof/target.mk
+++ b/src/06_optimization/gprof/target.mk
@@ -5,7 +5,7 @@ ifeq ($(target),)
 target=nano
 endif
 
-CFLAGS=-Wall -Wextra -g -c -O1 -MD -std=gnu11 -D_GNU_SOURCE -pg
+CFLAGS=-Wall -Wextra -g -c -O1 -MD -std=gnu11 -D_GNU_SOURCE -pg ${EXTRA_CFLAGS}
 
 ifeq ($(target),nano)
 TOOLCHAIN_PATH=/buildroot/output/host/usr/bin/
@@ -29,11 +29,11 @@ OBJDIR=.obj/xu3
 EXEC=$(EXE)_a
 endif
 
-CC=$(TOOLCHAIN)gcc
-LD=$(TOOLCHAIN)gcc
-AR=$(TOOLCHAIN)ar
-STRIP=$(TOOLCHAIN)strip
-OBJDUMP=$(TOOLCHAIN)objdump
+CC?=$(TOOLCHAIN)gcc
+LD?=$(TOOLCHAIN)gcc
+AR?=$(TOOLCHAIN)ar
+STRIP?=$(TOOLCHAIN)strip
+OBJDUMP?=$(TOOLCHAIN)objdump
 
 OBJDIR=.obj/$(target)
 OBJS= $(addprefix $(OBJDIR)/, $(SRCS:.c=.o))

--- a/src/06_optimization/mmio/Makefile
+++ b/src/06_optimization/mmio/Makefile
@@ -5,7 +5,7 @@ ifeq ($(target),)
 target=nano
 endif
 
-CFLAGS=-Wall -Wextra -g -c -O1 -MD -std=gnu11 -D_GNU_SOURCE
+CFLAGS=-Wall -Wextra -g -c -O1 -MD -std=gnu11 -D_GNU_SOURCE ${EXTRA_CFLAGS}
 
 ifeq ($(target),nano)
 TOOLCHAIN_PATH=/buildroot/output/host/usr/bin/
@@ -20,11 +20,11 @@ ifeq ($(target),host)
 EXEC=$(EXE)_h
 endif
 
-CC=$(TOOLCHAIN)gcc
-LD=$(TOOLCHAIN)gcc
-AR=$(TOOLCHAIN)ar
-STRIP=$(TOOLCHAIN)strip
-OBJDUMP=$(TOOLCHAIN)objdump
+CC?=$(TOOLCHAIN)gcc
+LD?=$(TOOLCHAIN)gcc
+AR?=$(TOOLCHAIN)ar
+STRIP?=$(TOOLCHAIN)strip
+OBJDUMP?=$(TOOLCHAIN)objdump
 
 OBJDIR=.obj/$(target)
 OBJS= $(addprefix $(OBJDIR)/, $(SRCS:.c=.o))

--- a/src/06_optimization/trace/Makefile
+++ b/src/06_optimization/trace/Makefile
@@ -5,7 +5,7 @@ ifeq ($(target),)
 target=nano
 endif
 
-CFLAGS=-Wall -Wextra -g -c -O1 -MD -std=gnu11 -D_GNU_SOURCE
+CFLAGS=-Wall -Wextra -g -c -O1 -MD -std=gnu11 -D_GNU_SOURCE ${EXTRA_CFLAGS}
 
 ifeq ($(target),nano)
 TOOLCHAIN_PATH=/buildroot/output/host/usr/bin/
@@ -20,11 +20,11 @@ ifeq ($(target),host)
 EXEC=$(EXE)_h
 endif
 
-CC=$(TOOLCHAIN)gcc
-LD=$(TOOLCHAIN)gcc
-AR=$(TOOLCHAIN)ar
-STRIP=$(TOOLCHAIN)strip
-OBJDUMP=$(TOOLCHAIN)objdump
+CC?=$(TOOLCHAIN)gcc
+LD?=$(TOOLCHAIN)gcc
+AR?=$(TOOLCHAIN)ar
+STRIP?=$(TOOLCHAIN)strip
+OBJDUMP?=$(TOOLCHAIN)objdump
 
 OBJDIR=.obj/$(target)
 OBJS= $(addprefix $(OBJDIR)/, $(SRCS:.c=.o))

--- a/src/07_miniproj/oled/Makefile
+++ b/src/07_miniproj/oled/Makefile
@@ -7,14 +7,14 @@ target=nano
 TOOLCHAIN_PATH=/buildroot/output/host/usr/bin/
 TOOLCHAIN=$(TOOLCHAIN_PATH)aarch64-linux-
 CFLAGS=-Wall -Wextra -g -c -O0 -MD -std=gnu11
-CFLAGS+=-mcpu=cortex-a53 -funwind-tables
+CFLAGS+=-mcpu=cortex-a53 -funwind-tables ${EXTRA_CFLAGS}
 ##CFLAGS+=-O2 -fno-omit-frame-pointer
 OBJDIR=.obj/nano
 
-CC=$(TOOLCHAIN)gcc
-LD=$(TOOLCHAIN)gcc
-AR=$(TOOLCHAIN)ar
-STRIP=$(TOOLCHAIN)strip
+CC?=$(TOOLCHAIN)gcc
+LD?=$(TOOLCHAIN)gcc
+AR?=$(TOOLCHAIN)ar
+STRIP?=$(TOOLCHAIN)strip
 
 OBJDIR=.obj/$(target)
 OBJS= $(addprefix $(OBJDIR)/, $(SRCS:.c=.o))


### PR DESCRIPTION
Allow setting the toolchain elements via environment variables with a script like this:

```bash
#!/bin/bash

SCRIPT_PATH=$(realpath "$0")
SCRIPT_FOLDER_PATH=$(dirname "$SCRIPT_PATH")
SDK_PATH="$SCRIPT_FOLDER_PATH/aarch64-buildroot-linux-gnu_sdk-buildroot"

export PATH="${SDK_PATH}/bin:${PATH}"

export SYSROOT="${SDK_PATH}/aarch64-buildroot-linux-gnu/sysroot"

export CROSS_COMPILE="aarch64-buildroot-linux-gnu-"

export CC="${CROSS_COMPILE}gcc"
export CXX="${CROSS_COMPILE}g++"
export LD="${CROSS_COMPILE}gcc"
export AR="${CROSS_COMPILE}ar"
export AS="${CROSS_COMPILE}as"
export STRIP="${CROSS_COMPILE}strip"
export OBJDUMP="${CROSS_COMPILE}objdump"

export EXTRA_CFLAGS="--sysroot=${SYSROOT}"
export LDFLAGS="--sysroot=${SYSROOT}"
```

Locally i'm using this script to source the SDK, this simplifies cross compilation the application if we're building natively

Ideally we should also be able to override the TOOLCHAIN variable as well but since we're hardcoding CFLAGS with `-mcpu=cortex-a53`, the current makefiles won't build for the host anyway. Could be a possible improvement later though 


cc @supcik 